### PR TITLE
Add GPIOEventHandle

### DIFF
--- a/examples/event.py
+++ b/examples/event.py
@@ -1,0 +1,8 @@
+from gpiodev import GPIOEventHandle
+import time
+
+Button = GPIOEventHandle(17, mode="rising")
+
+while True:
+    print("reading")
+    print(Button.get())

--- a/gpiodev/__init__.py
+++ b/gpiodev/__init__.py
@@ -1,5 +1,6 @@
-from .gpio import GPIOHandle
+from .gpio import GPIOHandle, GPIOEventHandle
 
 __all__ = [
     "GPIOHandle",
+    "GPIOEventHandle",
 ]


### PR DESCRIPTION
To read the event from the GPIO line one needs to create a GPIOEventHandle.

The GPIOEventHandle.handle is a read-only file descriptor.
One can use standard read operations on it to get the event data.