### PR TITLE
Add possibility to use different gpiochip devices

### DIFF
--- a/examples/RedBlueLED.py
+++ b/examples/RedBlueLED.py
@@ -1,7 +1,7 @@
 from gpiodev import GPIOHandle
 import time
 
-RedBlueLED = GPIOHandle((26, 21), mode="out")
+RedBlueLED = GPIOHandle((26, 21))
 
 print(RedBlueLED.get_values())
 

--- a/examples/led.py
+++ b/examples/led.py
@@ -1,0 +1,22 @@
+from gpiodev import GPIOChip
+import time
+
+GPIO = GPIOChip()
+
+DoubleLED = GPIO.get_handle(
+    (12, 23),
+    label="DoubleLED",
+)
+
+all = (1, 1)
+none = (0, 0)
+first = (1, 0)
+second = (0, 1)
+
+print(GPIO.line_info(12))
+
+
+for state in [all, none, first, second, all, none]*10:
+    DoubleLED.set_values(state)
+    print(DoubleLED.get_values())
+    time.sleep(1)

--- a/examples/sonar.py
+++ b/examples/sonar.py
@@ -1,6 +1,7 @@
 from gpiodev import GPIOHandle, GPIOEventHandle
 import time
 
+
 class Sonar():
 
     def __init__(self, echo_pin, trigger_pin):
@@ -23,11 +24,9 @@ class Sonar():
 
         return (stop - start)*340.0/2.0
 
+
 S = Sonar(echo_pin=20, trigger_pin=21)
 
 while True:
     print(S.measure())
     time.sleep(5)
-
-
-

--- a/gpiodev/__init__.py
+++ b/gpiodev/__init__.py
@@ -1,6 +1,7 @@
-from .gpio import GPIOHandle, GPIOEventHandle
+from .gpio import GPIOChip, GPIOHandle, GPIOEventHandle
 
 __all__ = [
+    "GPIOChip",
     "GPIOHandle",
     "GPIOEventHandle",
 ]


### PR DESCRIPTION
By default we use `/dev/gpiochip0`, but now one can override it.