### PR TITLE
set GPIOEventHandle.gpio when gpio is not None

### DIFF
--- a/gpiodev/gpio.py
+++ b/gpiodev/gpio.py
@@ -287,8 +287,7 @@ class GPIOEventHandle:
             )
 
         self.label = label
-        if not gpio:
-            self.gpio = GPIOChip(_GPIO)
+        self.gpio = gpio or GPIOChip(_GPIO)
 
         handle_flags = GPIOHANDLE_REQUEST_INPUT
 


### PR DESCRIPTION
a small typo in code - when `gpio` is not `None` it's not assigned to the `GPIOEventHandle` class instance.